### PR TITLE
Fix extension toolbar displaying monochrome icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,9 @@
   "icons": {
     "128": "icon.png"
   },
+  "browser_action": {
+    "default_icon": "icon.png"
+  },
 
   "content_scripts": [
     {


### PR DESCRIPTION
[Fix for monochrome icon #2](https://github.com/habibalamin/pr-sidebar/issues/2)